### PR TITLE
api98: TCK Challenge: TCK should not require JPMS module-info.class

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -172,7 +172,7 @@
         <property name="report.dir" value="${report.api.dir}"/>
         <property name="test.suite" value="tests/api"/>
         <property name="ts.jte" value="ts.nojpms.jte"/>
-        <property name="ts.jtx" value="/lib/ts.nojpms.jtx"/>
+        <property name="ts.jtx" value="${ts.home}/lib/ts.nojpms.jtx"/>
         <property name="run.class.path" value="${class.path}"/>
         <javatest.batch/>
     </target>
@@ -187,7 +187,7 @@
         <property name="report.dir" value="${report.pluggability.dir}"/>
         <property name="test.suite" value="tests/pluggability"/>
         <property name="ts.jte" value="ts.pluggability.nojpms.jte"/>
-        <property name="ts.jtx" value="/lib/ts.nojpms.jtx"/>
+        <property name="ts.jtx" value="${ts.home}/lib/ts.nojpms.jtx"/>
         <property name="run.class.path" value="${pluggability.class.path}"/>
         <javatest.batch/>
     </target>

--- a/build.xml
+++ b/build.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2012, 2022 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2012, 2023 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -138,25 +138,59 @@
         <local name="run.class.path"/>
         <local name="report.dir"/>
         <local name="test.suite"/>
+        <local name="ts.jtx"/>
     	<property name="report.dir" value="${report.api.dir}"/>
     	<property name="test.suite" value="tests/api"/>
     	<property name="ts.jte" value="ts.jte"/>
+        <property name="ts.jtx" value="${ts.home}/lib/ts.jtx"/>
         <property name="run.class.path" value="${class.path}"/>
         <javatest.batch/>
     </target>
 	
 	<target name="run.pluggability"
-	            description="Executes the JAF TCK in batch mode">
+	            description="Executes the JAF TCK pluggability tests in batch mode">
         <local name="ts.jte"/>
         <local name="run.class.path"/>
         <local name="report.dir"/>
 		<local name="test.suite"/>
+        <local name="ts.jtx"/>
         <property name="report.dir" value="${report.pluggability.dir}"/>
         <property name="test.suite" value="tests/pluggability"/>
         <property name="ts.jte" value="ts.pluggability.jte"/>
+        <property name="ts.jtx" value="${ts.home}/lib/ts.jtx"/>
         <property name="run.class.path" value="${pluggability.class.path}"/>
         <javatest.batch/>
 	</target>
+
+    <target name="run.nojpms"
+            description="Executes the JAF TCK in CLASS-PATH mode in batch mode">
+        <local name="ts.jte"/>
+        <local name="run.class.path"/>
+        <local name="report.dir"/>
+        <local name="test.suite"/>
+        <local name="ts.jtx"/>
+        <property name="report.dir" value="${report.api.dir}"/>
+        <property name="test.suite" value="tests/api"/>
+        <property name="ts.jte" value="ts.nojpms.jte"/>
+        <property name="ts.jtx" value="/lib/ts.nojpms.jtx"/>
+        <property name="run.class.path" value="${class.path}"/>
+        <javatest.batch/>
+    </target>
+
+    <target name="run.pluggability.nojpms"
+            description="Executes the JAF TCK pluggability tests in CLASS-PATH mode in batch mode">
+        <local name="ts.jte"/>
+        <local name="run.class.path"/>
+        <local name="report.dir"/>
+        <local name="test.suite"/>
+        <local name="ts.jtx"/>
+        <property name="report.dir" value="${report.pluggability.dir}"/>
+        <property name="test.suite" value="tests/pluggability"/>
+        <property name="ts.jte" value="ts.pluggability.nojpms.jte"/>
+        <property name="ts.jtx" value="/lib/ts.nojpms.jtx"/>
+        <property name="run.class.path" value="${pluggability.class.path}"/>
+        <javatest.batch/>
+    </target>
 
     <target name="gui"
             description="Executes the JAF TCK in GUI mode">
@@ -213,7 +247,7 @@
             <arg line=" -workdir ${work.dir}" />
             <arg line=" -envFiles ${ts.home}/lib/${ts.jte}" />
             <arg line=" -env jafUnix" />
-            <arg line=" -excludeList ${ts.home}/lib/ts.jtx" />
+            <arg line=" -excludeList ${ts.jtx}" />
             <arg line=" -timeoutFactor 1" />
             <arg line=" ${tests.arg}" />
             <arg line=" -runtests -writereport ${report.dir}"/>

--- a/docs/ReleaseNotes-2.1.html
+++ b/docs/ReleaseNotes-2.1.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
 <!--
 
-    Copyright (c) 2018, 2021 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2023 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -42,7 +42,7 @@
   <body>
     <div align="center">
       <h1>Jakarta Activation Technology Compatibility Kit, Version 2.1</h1>
-      <h2> <em class="emphasize">Release Notes, November, 2021</em></h2>
+      <h2> <em class="emphasize">Release Notes, March, 2023</em></h2>
     </div>
     <h2><a name="kit_contents">Kit Contents</a></h2>
     <p>The Jakarta Activation, Version 2.1 Technology Compatibility Kit
@@ -104,7 +104,7 @@
       available <a href="https://wiki.openjdk.java.net/display/CodeTools/Documentation">here</a>.</p>
     <hr>
     <p>
-      <cite> <small>Copyright (c) 2017, 2021 Oracle and/or its affiliates. All rights reserved.</small></cite>
+      <cite> <small>Copyright (c) 2017, 2023 Oracle and/or its affiliates. All rights reserved.</small></cite>
     </p>
   </body>
 </html>

--- a/docs/ug/pom.xml
+++ b/docs/ug/pom.xml
@@ -212,11 +212,6 @@
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-clean-plugin</artifactId>
-                    <version>3.1.0</version>
-                </plugin>
-                <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-enforcer-plugin</artifactId>
                     <version>3.0.0-M3</version>
                 </plugin>

--- a/docs/ug/src/main/jbake/content/config.adoc
+++ b/docs/ug/src/main/jbake/content/config.adoc
@@ -71,7 +71,10 @@ slashes as a path separator instead.
   {TechnologyVersion} CI has been installed
   e.  `PATH` to include the following directories: `JAVA_HOME/bin`
   and `ANT_HOME/bin`
-2.  Edit your +{jteFileName}+ file and set the following
+2.  If the Vendor Implementation does not provide Java Platform module descriptor,
+move `<TS_HOME>/lib/ts.nojpms.jte` into +{jteFileName}+ file
+and `<TS_HOME>/lib/ts.pluggability.nojpms.jte` into +{jtePluggabilityFileName}+ file.
+3.  Edit your +{jteFileName}+ file and set the following
 environment variables:
   a.  Set the `JAVA_HOME` property to the directory in which Java SE {SEversion}
   is installed.
@@ -79,7 +82,7 @@ environment variables:
   {TechnologyShortName} TCK {TechnologyVersion} software is installed.
   c.  Set the +{TechnologyHomeEnv}+ property to the directory in which the
   {TechnologyShortName} {TechnologyVersion} CI has been installed.
-3. Run the JavaTest harness in GUI or command-line mode, as described in
+4. Run the JavaTest harness in GUI or command-line mode, as described in
 link:#GBFUY[Section 4.4, "Using the JavaTest Harness Software."]
 
 [[GCLHU]][[configuring-your-environment-to-run-the-tck-against-the-vendor-implementation]]
@@ -118,7 +121,10 @@ slashes as a path separator instead.
   {TechnologyVersion} Vendor Implementation has been installed
   d.  `PATH` to include the following directories: `JAVA_HOME/bin`
   and `ANT_HOME/bin`
-2.  Edit your +{jteFileName}+ file and set the following
+2.  If the Vendor Implementation does not provide Java Platform module descriptor,
+move `<TS_HOME>/lib/ts.nojpms.jte` into +{jteFileName}+ file
+and `<TS_HOME>/lib/ts.pluggability.nojpms.jte` into +{jtePluggabilityFileName}+ file.
+3.  Edit your +{jteFileName}+ file and set the following
 environment variables:
   a.  Set the `JAVA_HOME` property to the directory in which Java SE {SEversion}
   is installed.
@@ -127,7 +133,7 @@ environment variables:
   c.  Set the +{TechnologyHomeEnv}+ property to the directory in which the
   {TechnologyShortName} {TechnologyVersion} Vendor Implementation has been
   installed.
-3. Run the JavaTest harness in GUI or command-line mode, as described in
+4. Run the JavaTest harness in GUI or command-line mode, as described in
 link:#GBFUY[Section 4.4, "Using the JavaTest Harness Software."]
 
 

--- a/docs/ug/src/main/jbake/content/title.adoc
+++ b/docs/ug/src/main/jbake/content/title.adoc
@@ -17,7 +17,7 @@ Technology Compatibility Kit User's Guide for {TechnologyFullName}
 
 Release {TechnologyVersion} for Jakarta EE
 
-November 2021
+March 2023
 
 [[sthref1]]
 
@@ -26,7 +26,7 @@ November 2021
 Technology Compatibility Kit User's Guide for {TechnologyFullName},
 Release {TechnologyVersion} for Jakarta EE
 
-Copyright © 2017, 2021 Oracle and/or its affiliates. All rights reserved.
+Copyright © 2017, 2023 Oracle and/or its affiliates. All rights reserved.
 
 This program and the accompanying materials are made available under
 the terms of the Eclipse Public License v. 2.0, which is available at

--- a/docs/ug/src/main/jbake/templates/footer.ftl
+++ b/docs/ug/src/main/jbake/templates/footer.ftl
@@ -37,7 +37,7 @@
 
 <span id="copyright">
 		<img src="img/eclipse_foundation_logo_tiny.png" height="20px" alt="Eclipse Foundation Logo" align="top"/>&nbsp;			
-		<span >Copyright&nbsp;&copy;&nbsp;2018,&nbsp;2020&nbsp;Oracle&nbsp;and/or&nbsp;its&nbsp;affiliates.&nbsp;All&nbsp;rights&nbsp;reserved.</span>
+		<span >Copyright &copy; 2018, 2023&nbsp;Oracle&nbsp;and/or&nbsp;its&nbsp;affiliates.&nbsp;All&nbsp;rights&nbsp;reserved.</span>
 </span>
 
 </body>

--- a/lib/ts.nojpms.jte
+++ b/lib/ts.nojpms.jte
@@ -52,15 +52,15 @@ JARPATH=MUST-BE-SET
 #API_JAR=${JARPATH}\\jakarta.activation-api.jar
 API_JAR=${JARPATH}/jakarta.activation-api.jar
 
-# Set the Activation implementation path 
+# Set the Activation implementation path
 ##CI_JAR=$JARPATH\\angus-activation.jar
 CI_JAR=$JARPATH/angus-activation.jar
 
 ##TESTCLASS=$TS_HOME\\classes
 TESTCLASS=$TS_HOME/classes
 
-##extraOtherJVMClassPath=$TS_HOME\\sigtest.jar;$CI_JAR;$TESTCLASS
-extraOtherJVMClassPath=$TS_HOME/sigtest.jar:$CI_JAR:$TESTCLASS
+##extraOtherJVMClassPath=$TS_HOME\\sigtest.jar;$API_JAR;$CI_JAR;$TESTCLASS
+extraOtherJVMClassPath=$TS_HOME/sigtest.jar:$API_JAR:$CI_JAR:$TESTCLASS
 
 ##javatestClassDir=$TS_HOME\\javatest.jar
 javatestClassDir=$TS_HOME/javatest.jar
@@ -117,7 +117,7 @@ env.jafUnix.description=\
 	Run the runtime tests in a separate JVM (process) on UNIX
 env.jafUnix.finder=$TCKTestFinder
 env.jafUnix.script=$TCKScript
- 
+
 #
 # The runtime to be tested ...
 #
@@ -125,7 +125,7 @@ env.jafUnix.command.execute=$ExecTCKTestOtherJVMCmd \
 	CLASSPATH=$testSuiteRootDir/../classes:$testClassDir:\
 	$javatestClassDir:$extraOtherJVMClassPath \
 	HOME=${user.home} \
-	$JAVA_HOME/bin/java --add-modules jakarta.activation --module-path $API_JAR -verify $testExecuteClass $testExecuteArgs $testDebug
+	$JAVA_HOME/bin/java -verify $testExecuteClass $testExecuteArgs $testDebug
 
 
 #---------- JDK/Windows NT configuration ---------------------------------------
@@ -143,7 +143,7 @@ env.jafWindows.script=$TCKScript
 # in a separate JVM (process) on Windows NT.
 #
 # The runtime to be tested ...
-# 	The SystemRoot variable should be set to the Windows NT system 
+# 	The SystemRoot variable should be set to the Windows NT system
 #	installation directory.
 #
 # You can either set the value of SystemRoot explicitly, or you can set it to
@@ -154,4 +154,4 @@ env.jafWindows.command.execute=$ExecTCKTestOtherJVMCmd \
 	CLASSPATH=$testSuiteRootDir$/..$/classes:$javatestClassDir:$extraOtherJVMClassPath \
 	SystemRoot=${SYSTEMROOT} \
 	windir=${SYSTEMROOT} \
-	$JAVA_HOME$/bin$/java --add-modules jakarta.activation --module-path $API_JAR -verify $testExecuteClass $testExecuteArgs $testDebug
+	$JAVA_HOME$/bin$/java -verify $testExecuteClass $testExecuteArgs $testDebug

--- a/lib/ts.nojpms.jtx
+++ b/lib/ts.nojpms.jtx
@@ -1,0 +1,19 @@
+#
+# Copyright (c) 2018, 2023 Oracle and/or its affiliates. All rights reserved.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Eclipse Public License v. 2.0, which is available at
+# http://www.eclipse.org/legal/epl-2.0.
+#
+# This Source Code may also be made available under the following Secondary
+# Licenses when the conditions for such availability set forth in the
+# Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+# version 2 with the GNU Classpath Exception, which is available at
+# https://www.gnu.org/software/classpath/license.html.
+#
+# SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+#
+
+# exclude the following tests
+javasoft/sqe/tests/jakarta/activation/CommandMap/testlist.html#createDataContentHandler_Test
+javasoft/sqe/tests/jakarta/activation/Module/testlist.html#UnnamedModule_Test

--- a/lib/ts.pluggability.nojpms.jte
+++ b/lib/ts.pluggability.nojpms.jte
@@ -59,8 +59,8 @@ LOCAL_CLASSES=$TS_HOME/classes-providers/activation_alternate_provider.jar
 ##TESTCLASS=$TS_HOME\\classes
 TESTCLASS=$TS_HOME/classes-pluggability
 
-##extraOtherJVMClassPath=$TS_HOME\\sigtest.jar;$LOCAL_CLASSES;$API_JAR:$CI_JAR;$TESTCLASS
-extraOtherJVMClassPath=$TS_HOME/sigtest.jar:$LOCAL_CLASSES:$API_JAR:$CI_JAR:$TESTCLASS
+##extraOtherJVMClassPath=$TS_HOME\\sigtest.jar;$LOCAL_CLASSES;$API_JAR;$TESTCLASS
+extraOtherJVMClassPath=$TS_HOME/sigtest.jar:$LOCAL_CLASSES:$API_JAR:$TESTCLASS
 
 ##javatestClassDir=$TS_HOME\\javatest.jar
 javatestClassDir=$TS_HOME/javatest.jar

--- a/lib/ts.pluggability.nojpms.jte
+++ b/lib/ts.pluggability.nojpms.jte
@@ -53,14 +53,14 @@ JARPATH=MUST-BE-SET
 API_JAR=${JARPATH}/jakarta.activation-api.jar
 
 # Set the Activation implementation path 
-##CI_JAR=$JARPATH\\angus-activation.jar
-CI_JAR=$JARPATH/angus-activation.jar
+##LOCAL_CLASSES=$JARPATH\\angus-activation.jar
+LOCAL_CLASSES=$TS_HOME/classes-providers/activation_alternate_provider.jar
 
 ##TESTCLASS=$TS_HOME\\classes
-TESTCLASS=$TS_HOME/classes
+TESTCLASS=$TS_HOME/classes-pluggability
 
-##extraOtherJVMClassPath=$TS_HOME\\sigtest.jar;$CI_JAR;$TESTCLASS
-extraOtherJVMClassPath=$TS_HOME/sigtest.jar:$CI_JAR:$TESTCLASS
+##extraOtherJVMClassPath=$TS_HOME\\sigtest.jar;$LOCAL_CLASSES;$API_JAR:$CI_JAR;$TESTCLASS
+extraOtherJVMClassPath=$TS_HOME/sigtest.jar:$LOCAL_CLASSES:$API_JAR:$CI_JAR:$TESTCLASS
 
 ##javatestClassDir=$TS_HOME\\javatest.jar
 javatestClassDir=$TS_HOME/javatest.jar
@@ -74,7 +74,7 @@ JAVAMAIL_TESTDATA_DIR=$TS_HOME/tests/testdata
 
 #Test URL for signature tests.
 # This should be set to the installation <Directory of the TCK>/tests
-testURL=file://$TS_HOME/tests
+testURL=file://$TS_HOME/tests/pluggability
 
 
 # Shorthand forms, for convenience.
@@ -117,15 +117,15 @@ env.jafUnix.description=\
 	Run the runtime tests in a separate JVM (process) on UNIX
 env.jafUnix.finder=$TCKTestFinder
 env.jafUnix.script=$TCKScript
- 
+
 #
 # The runtime to be tested ...
 #
 env.jafUnix.command.execute=$ExecTCKTestOtherJVMCmd \
-	CLASSPATH=$testSuiteRootDir/../classes:$testClassDir:\
+	CLASSPATH=$testSuiteRootDir/../classes-pluggability:$testClassDir:\
 	$javatestClassDir:$extraOtherJVMClassPath \
 	HOME=${user.home} \
-	$JAVA_HOME/bin/java --add-modules jakarta.activation --module-path $API_JAR -verify $testExecuteClass $testExecuteArgs $testDebug
+	$JAVA_HOME/bin/java -verify $testExecuteClass $testExecuteArgs $testDebug
 
 
 #---------- JDK/Windows NT configuration ---------------------------------------
@@ -143,7 +143,7 @@ env.jafWindows.script=$TCKScript
 # in a separate JVM (process) on Windows NT.
 #
 # The runtime to be tested ...
-# 	The SystemRoot variable should be set to the Windows NT system 
+# 	The SystemRoot variable should be set to the Windows NT system
 #	installation directory.
 #
 # You can either set the value of SystemRoot explicitly, or you can set it to
@@ -151,7 +151,7 @@ env.jafWindows.script=$TCKScript
 # JavaTest, which might in turn be set from your Windows NT SystemRoot variable.
 #
 env.jafWindows.command.execute=$ExecTCKTestOtherJVMCmd \
-	CLASSPATH=$testSuiteRootDir$/..$/classes:$javatestClassDir:$extraOtherJVMClassPath \
+	CLASSPATH=$testSuiteRootDir$/..$/classes-pluggability:$javatestClassDir:$extraOtherJVMClassPath \
 	SystemRoot=${SYSTEMROOT} \
 	windir=${SYSTEMROOT} \
-	$JAVA_HOME$/bin$/java --add-modules jakarta.activation --module-path $API_JAR -verify $testExecuteClass $testExecuteArgs $testDebug
+	$JAVA_HOME$/bin$/java -verify $testExecuteClass $testExecuteArgs $testDebug

--- a/tests/api/javasoft/sqe/tests/jakarta/activation/Module/UnnamedModule_Test.java
+++ b/tests/api/javasoft/sqe/tests/jakarta/activation/Module/UnnamedModule_Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2023 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -35,12 +35,16 @@ public class UnnamedModule_Test extends MultiTest {
     }
 
     public Status test() {
-        String moduleName = DataSource.class.getModule().getName();
-        if (ACTIVATION_API_MODULE.equals(moduleName)) {
-            return Status.passed(moduleName);
-        } else { 
-            return Status.failed(ACTIVATION_API_MODULE + " is not visible");
+        Module m = DataSource.class.getModule();
+        if (m.isNamed()) {
+            String moduleName = m.getName();
+            if (ACTIVATION_API_MODULE.equals(moduleName)) {
+                return Status.passed(moduleName);
+            } else {
+                return Status.failed("Module name must be: '" + ACTIVATION_API_MODULE + "' but is '" + moduleName + "'");
+            }
         }
+        return Status.failed(ACTIVATION_API_MODULE + " module is not on the module path");
     }
 
 }

--- a/tests/api/javasoft/sqe/tests/jakarta/activation/Module/testlist.html
+++ b/tests/api/javasoft/sqe/tests/jakarta/activation/Module/testlist.html
@@ -2,7 +2,7 @@
 <HEAD>
 <!--
 
-    Copyright (c) 2021 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2021, 2023 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -41,7 +41,7 @@ The following are the test descriptions for the tests developed.Links to the sou
 <TABLE BORDER class=TestDescription>
 <TR><TD><B>title</B></TD><TD>UnnamedModule_Test() API</TD></TR>
 <TR><TD><B>name</B></TD><TD>test</TD></TR>
-<TR><TD><B>source</B></TD><TD><A HREF=MimeTypeRegistryProvider_Test.java>UnnamedModule_Test.java</A></TD></TR>
+<TR><TD><B>source</B></TD><TD><A HREF=UnnamedModule_Test.java>UnnamedModule_Test.java</A></TD></TR>
 <TR><TD><B>executeClass</B></TD><TD>javasoft.sqe.tests.jakarta.activation.Module.UnnamedModule_Test</TD></TR>
 <TR><TD><B>keywords</B></TD><TD></TD></TR>
 </TABLE>


### PR DESCRIPTION
this is supposed to address https://github.com/jakartaee/jaf-api/issues/98

@scottmarlow @brideck - review, please