### PR TITLE
 4.0.2 service release of Activation TCK with JDK11 build. TCK runs on JDK11,17,21.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -41,15 +41,15 @@ spec:
            defaultValue: '',
            description: 'Base URL required for downloading prebuilt binary TCK Bundle from a hosted location' )
     string(name: 'TCK_BUNDLE_FILE_NAME', 
-           defaultValue: 'jakarta-activation-tck-2.1.0.zip', 
+           defaultValue: 'jakarta-activation-tck-2.1.2.zip', 
 	   description: 'Name of bundle file to be appended to the base url' )
     string(name: 'GF_BUNDLE_URL', 
            defaultValue: 'https://download.eclipse.org/ee4j/glassfish/glassfish-7.0.0.zip', 
            description: 'URL required for downloading GlassFish Full/Web profile bundle' )
     choice(name: 'RUNTIME', choices: 'Glassfish\nANGUS',
            description: 'Run JAF Tests with Angus/Glassfish' )
-    choice(name: 'JDK', choices: 'JDK21',
-           description: 'Java SE Version to be used for running TCK either JDK21' )
+    choice(name: 'JDK', choices: 'JDK11\nJDK17\nJDK21',
+           description: 'Java SE Version to be used for running TCK either JDK11 or JDK17 or JDK21' )
     choice(name: 'LICENSE', choices: 'EPL\nEFTL',
            description: 'License file to be used to build the TCK bundle(s) either EPL(default) or Eclipse Foundation TCK License' )
   }

--- a/build.xml
+++ b/build.xml
@@ -21,7 +21,7 @@
     <description>Builds and runs the project activation-tck.</description>
 
     <property name="version" value="2.1"/>
-    <property name="version.tck" value="2.1.1"/>
+    <property name="version.tck" value="2.1.2"/>
     <property name="api.module.name" value="jakarta.activation"/>
 
 

--- a/docker/build_activationtck.sh
+++ b/docker/build_activationtck.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -x
 #
-# Copyright (c) 2018, 2023 Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2018, 2024 Oracle and/or its affiliates. All rights reserved.
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License v. 2.0, which is available at
@@ -17,11 +17,7 @@
 
 cd $WORKSPACE
 
-wget https://download.java.net/java/GA/jdk21.0.1/415e3f918a1f4062a0074a2794853d0d/12/GPL/openjdk-21.0.1_linux-x64_bin.tar.gz -O jdk-21.tar.gz
-tar -xvf jdk-21.tar.gz
-export JAVA_HOME=$WORKSPACE/jdk-21.0.1
-export PATH=$JAVA_HOME/bin:$PATH
-
+export JAVA_HOME=${JDK11_HOME}
 
 echo "ANT_HOME=$ANT_HOME"
 echo "export JAVA_HOME=$JAVA_HOME"

--- a/docker/run_activationtck.sh
+++ b/docker/run_activationtck.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -xe
 #
-# Copyright (c) 2018, 2023 Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2018, 2024 Oracle and/or its affiliates. All rights reserved.
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License v. 2.0, which is available at
@@ -31,7 +31,9 @@ export TS_HOME=${WORKSPACE}/${TCK_NAME}
 
 cd $WORKSPACE
 
-if [[ "$JDK" == "JDK21" || "$JDK" == "jdk21" ]];then
+if [[ "$JDK" == "JDK17" || "$JDK" == "jdk17" ]];then
+  export JAVA_HOME=${JDK17_HOME}
+elif [[ "$JDK" == "JDK21" || "$JDK" == "jdk21" ]];then
   wget https://download.java.net/java/GA/jdk21.0.1/415e3f918a1f4062a0074a2794853d0d/12/GPL/openjdk-21.0.1_linux-x64_bin.tar.gz -O jdk-21.tar.gz
   tar -xvf jdk-21.tar.gz
   export JAVA_HOME=$WORKSPACE/jdk-21.0.1

--- a/docs/ug/pom.xml
+++ b/docs/ug/pom.xml
@@ -28,7 +28,7 @@
     <groupId>com.sun.activation</groupId>
     <artifactId>tck_ug</artifactId>
     <packaging>pom</packaging>
-    <version>2.1.1-SNAPSHOT</version>
+    <version>2.1.2-SNAPSHOT</version>
     <name>Eclipse Foundation Technology Compatibility Kit User's Guide for Jakarta Activation Framework 2.1 for Jakarta EE, Release 2.1</name>
 
     <properties>

--- a/docs/ug/src/main/jbake/content/attributes.conf
+++ b/docs/ug/src/main/jbake/content/attributes.conf
@@ -27,7 +27,7 @@
 :jteFileName: <TS_HOME>/lib/ts.jte
 :jtePluggabilityFileName: <TS_HOME>/lib/ts.pluggability.jte
 :jtxFileName: <TS_HOME>/lib/ts.jtx
-:TCKPackageName: jakarta-activation-tck-2.1.1.zip
+:TCKPackageName: jakarta-activation-tck-2.1.2.zip
 // Directory names used in examples in using.adoc.
 :sigTestDirectoryExample: <TS_HOME>/tests
 :singleTestDirectoryExample: <TS_HOME>/tests/api/javasoft/sqe/tests/jakarta/activation/ActivationDataFlavor


### PR DESCRIPTION
 4.0.2 service release of Activation TCK with JDK11 build. TCK runs on JDK11,17,21. 